### PR TITLE
Add a fallback for finding view's lifecycle

### DIFF
--- a/base/src/main/kotlin/io/goooler/demoapp/base/util/BaseExtensions.kt
+++ b/base/src/main/kotlin/io/goooler/demoapp/base/util/BaseExtensions.kt
@@ -524,8 +524,8 @@ inline val Context?.lifecycle: Lifecycle?
     while (true) {
       when (context) {
         is LifecycleOwner -> return context.lifecycle
-        !is ContextWrapper -> return null
-        else -> context = context.baseContext
+        is ContextWrapper -> context = context.baseContext
+        else -> return null
       }
     }
   }

--- a/base/src/main/kotlin/io/goooler/demoapp/base/util/BaseExtensions.kt
+++ b/base/src/main/kotlin/io/goooler/demoapp/base/util/BaseExtensions.kt
@@ -540,8 +540,7 @@ fun TextView.setOnEditorConfirmActionListener(listener: (TextView) -> Unit) {
     val isConfirmAction = if (event != null) {
       when (event.keyCode) {
         KeyEvent.KEYCODE_DPAD_CENTER, KeyEvent.KEYCODE_ENTER,
-        KeyEvent.KEYCODE_NUMPAD_ENTER,
-        -> true
+        KeyEvent.KEYCODE_NUMPAD_ENTER, -> true
         else -> false
       } && event.action == KeyEvent.ACTION_DOWN
     } else {


### PR DESCRIPTION
If we use `View.lifecycle` to find a recyclerView's itemView's lifecycle when it has not been attached to window, the result is `null`, so that we need to add a fallback for this case.

```java
    void dispatchChildAttached(View child) {
        final ViewHolder viewHolder = getChildViewHolderInt(child);
        onChildAttachedToWindow(child);
        if (mAdapter != null && viewHolder != null) {
            mAdapter.onViewAttachedToWindow(viewHolder);
        }
        if (mOnChildAttachStateListeners != null) {
            final int cnt = mOnChildAttachStateListeners.size();
            for (int i = cnt - 1; i >= 0; i--) {
                mOnChildAttachStateListeners.get(i).onChildViewAttachedToWindow(child);
            }
        }
    }
```