### PR TITLE
Remove @Keep on BaseResponse

### DIFF
--- a/common/src/main/kotlin/io/goooler/demoapp/common/network/BaseResponse.kt
+++ b/common/src/main/kotlin/io/goooler/demoapp/common/network/BaseResponse.kt
@@ -1,8 +1,5 @@
 package io.goooler.demoapp.common.network
 
-import androidx.annotation.Keep
-
-@Keep
 abstract class BaseResponse(
   val message: String? = null,
   val code: Int = -1,


### PR DESCRIPTION
No need to keep `BaseResponse` after 3e6e8ac3ed94aa2781e54a21a4c9bd1af4c3b8af.

Picked from #198.