### PR TITLE
Remove java sourceSets's extra config

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -91,9 +91,6 @@ fun Project.setupBase(): BaseExtension {
       vectorDrawables.useSupportLibrary = true
       testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
-    sourceSets.configureEach {
-      java.srcDirs("src/$name/kotlin")
-    }
     compileOptions {
       targetCompatibility(JavaVersion.VERSION_11)
       sourceCompatibility(JavaVersion.VERSION_11)


### PR DESCRIPTION
Follow up #225, the `NaptTrigger` only be used as a trigger, no need to be compiled.