### PR TITLE
Remove Napt triggers

### DIFF
--- a/adapter/src/main/kotlin/io/goooler/demoapp/adapter/util/NaptTrigger.java
+++ b/adapter/src/main/kotlin/io/goooler/demoapp/adapter/util/NaptTrigger.java
@@ -1,4 +1,0 @@
-package io.goooler.demoapp.adapter.util;
-
-class NaptTrigger {
-}

--- a/app/src/main/kotlin/io/goooler/demoapp/app/util/NaptTrigger.java
+++ b/app/src/main/kotlin/io/goooler/demoapp/app/util/NaptTrigger.java
@@ -1,4 +1,0 @@
-package io.goooler.demoapp.app.util;
-
-class NaptTrigger {
-}

--- a/base/src/main/kotlin/io/goooler/demoapp/base/util/NaptTrigger.java
+++ b/base/src/main/kotlin/io/goooler/demoapp/base/util/NaptTrigger.java
@@ -1,4 +1,0 @@
-package io.goooler.demoapp.base.util;
-
-class NaptTrigger {
-}

--- a/biz/login/src/main/kotlin/io/goooler/demoapp/login/util/NaptTrigger.java
+++ b/biz/login/src/main/kotlin/io/goooler/demoapp/login/util/NaptTrigger.java
@@ -1,4 +1,0 @@
-package io.goooler.demoapp.login.util;
-
-class NaptTrigger {
-}

--- a/biz/main/src/main/kotlin/io/goooler/demoapp/main/util/NaptTrigger.java
+++ b/biz/main/src/main/kotlin/io/goooler/demoapp/main/util/NaptTrigger.java
@@ -1,4 +1,0 @@
-package io.goooler.demoapp.main.util;
-
-class NaptTrigger {
-}

--- a/biz/web/src/main/kotlin/io/goooler/demoapp/web/util/NaptTrigger.java
+++ b/biz/web/src/main/kotlin/io/goooler/demoapp/web/util/NaptTrigger.java
@@ -1,4 +1,0 @@
-package io.goooler.demoapp.web.util;
-
-class NaptTrigger {
-}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,5 @@
 import com.android.build.gradle.BaseExtension
 import com.google.devtools.ksp.gradle.KspExtension
-import com.slapin.napt.NaptGradleExtension
 import io.gitlab.arturbosch.detekt.extensions.DetektExtension
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
@@ -27,11 +26,6 @@ allprojects {
   }
   plugins.withId(rootProject.libs.plugins.android.application.get().pluginId) {
     setupCommon()
-  }
-  plugins.withId(rootProject.libs.plugins.napt.get().pluginId) {
-    configure<NaptGradleExtension> {
-      generateNaptTrigger.set(false)
-    }
   }
   plugins.withId(rootProject.libs.plugins.ksp.get().pluginId) {
     configure<KspExtension> {

--- a/common/src/main/kotlin/io/goooler/demoapp/common/util/NaptTrigger.java
+++ b/common/src/main/kotlin/io/goooler/demoapp/common/util/NaptTrigger.java
@@ -1,4 +1,0 @@
-package io.goooler.demoapp.common.util;
-
-class NaptTrigger {
-}


### PR DESCRIPTION
Follow up #227 & #225, triggers are generated in `module/build/generate/source` dir now.

https://github.com/sergei-lapin/napt/releases/tag/1.17