### PR TITLE
Bump R8 for AGP 8

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -7,7 +7,7 @@ pluginManagement {
 
   buildscript {
     dependencies {
-      classpath("com.android.tools:r8:4.0.48")
+      classpath("com.android.tools:r8:4.0.52")
     }
   }
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -7,7 +7,7 @@ pluginManagement {
 
   buildscript {
     dependencies {
-      classpath("com.android.tools:r8:4.0.52")
+      classpath("com.android.tools:r8:8.0.40")
     }
   }
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -2,6 +2,13 @@ pluginManagement {
   repositories {
     google()
     gradlePluginPortal()
+    maven("https://storage.googleapis.com/r8-releases/raw")
+  }
+
+  buildscript {
+    dependencies {
+      classpath("com.android.tools:r8:4.0.48")
+    }
   }
 }
 


### PR DESCRIPTION
The current default version is `8.0.35 (build 0e52f7d614672f837ec8c231a71d63b0b0d19ccd from go/r8bot (luci-r8-custom-ci-bionic-45-18q0))`.